### PR TITLE
Changed: make value public so it could be used as template parameter

### DIFF
--- a/strong_alias.h
+++ b/strong_alias.h
@@ -55,10 +55,8 @@ namespace strong
     template <typename T, typename Name> requires std::is_scalar_v<T>
     struct alias<T, Name> : alias_name<Name>
     {
-    private:
         T value;
 
-    public:
         template<typename... Args> requires (is_alias<Args>&& ...)
         explicit constexpr alias(Args&&... args) noexcept(((std::is_lvalue_reference_v<Args>&& ...) && std::is_nothrow_copy_constructible_v<T>) or ((std::is_rvalue_reference_v<Args> && ...) && std::is_nothrow_move_constructible_v<T>))
             : value{ std::forward<Args>(args)... } { static_assert(sizeof...(Args) <= 1); };

--- a/strong_alias.h
+++ b/strong_alias.h
@@ -64,6 +64,7 @@ namespace strong
     {
         T value;
 
+        using underlying_t = T;
         using explicit_conversion_from_t = std::false_type;
         
         template<typename... Args> requires (is_alias<Args>&& ...)
@@ -137,6 +138,7 @@ namespace strong
     struct alias<T, Name> : alias_name<Name>, T
     {
     public:
+        using underlying_t = T;
         using explicit_conversion_from_t = std::false_type;
         
         template<typename... Args>


### PR DESCRIPTION
> [all base classes and non-static data members are public and non-mutable and ](https://en.cppreference.com/w/cpp/language/template_parameters.html)

I want to find a way to implement "strong typed alias for enum class", and `don't` want the implicit conversion from the original enum class type. It's done with these two commits.



So that `EYesOrNo` could be used as `EWantBreakfast`, `EWantLunch`, `EWantDinner` in :

```cpp
OrderMeal<EWantBreakfast::Yes, EWantLunch::No, EWantDinner::Yes>();
```

_Ideally_ 👆

But in reality ;) The best I could only got ATM :

```cpp
OrderMeal<EWantBreakfast{EYesOrNo::Yes}, EWantLunch{EYesOrNo::No}, EWantDinner{EYesOrNo::Yes}>();
```


BTW, why it don't have `get` to return reference to `value`? Is there any special consideration for it?